### PR TITLE
グッズ登録機能

### DIFF
--- a/backend/app/api/item.py
+++ b/backend/app/api/item.py
@@ -1,0 +1,46 @@
+# backend/app/api/item.py
+from typing import List
+from app.models import Item
+from app.database.db_item import create_item
+from pydantic import BaseModel, field_validator
+from datetime import date
+from bson import ObjectId
+from fastapi import APIRouter
+
+# PydanticがObjectId型を受け入れるようにする
+class BaseModelWithConfig(BaseModel):
+    class Config:
+        arbitrary_types_allowed = True # 任意の型を許可
+        json_encoders = {
+            ObjectId: str # ObjectIdを文字列に変換する設定
+        }
+
+router = APIRouter()
+
+class ItemRequest(BaseModelWithConfig):    
+    item_name: str
+    item_images: List[str] # image_id
+    category: str #category_id
+    item_series: str # series_id
+    item_character: str #character_id
+    tags: List[str]
+    jan_code: str
+    release_date: date
+    retailers: List[str]
+    user_data: List[str] #user_id UserSpecificDataでこのアイテムを持っているユーザー
+
+    # カスタムバリデーションで文字列をObjectIdに変換
+    @field_validator("item_images", "user_data")
+    def validate_item_images(cls, v):
+        return [ObjectId(i) if isinstance(i, str) else i for i in v]
+
+    @field_validator("item_series", "item_character", "category")
+    def validate_object_id(cls, v):
+        return ObjectId(v) if isinstance(v, str) else v
+
+# グッズ（アイテム）登録
+@router.post("/api/items")
+async def create_item_endpoint(item_request: ItemRequest):
+    item = Item(**item_request.model_dump())
+    created_item = await create_item(item)
+    return created_item

--- a/backend/app/database/db_item.py
+++ b/backend/app/database/db_item.py
@@ -27,6 +27,14 @@ async def get_items():
         items = await Item.find_all().to_list()
         return items
     except Exception as e:
-        print(f"Error occurred: {e}")  # エラーログを出力
+        raise Exception(f"Error fetching items: {str(e)}")  # エラーログを出力
     finally:
         await db.disconnect()  # 接続を切断
+
+# 指定したユーザーの独自データ（カスタムアイテム等すべての詳細を含む）を取得する
+async def get_user_specific_data(user_id: str):
+    try:
+        user_specific_data = await UserSpecificData.find_one({"user_id": ObjectId(user_id)})
+        return user_specific_data
+    except Exception as e:
+        raise Exception(f"Error fetching user specific data: {str(e)}")  # エラーログを出力

--- a/backend/app/database/db_item.py
+++ b/backend/app/database/db_item.py
@@ -1,0 +1,21 @@
+# backend/app/database/db_item.py
+from app.models import Item
+from bson import ObjectId
+from fastapi import HTTPException
+from pydantic import BaseModel
+from app.database.db_connection import Database
+
+
+db = Database()
+
+# 新しいアイテムを作成する
+async def create_item(item: Item):
+    await db.connect()
+    print(item)  # 挿入するアイテムの内容を表示
+    try:
+        await item.insert()
+        return item
+    except Exception as e:
+        print(f"Error occurred: {e}")  # エラーログを出力
+    finally:
+        await db.disconnect()  # 接続を切断

--- a/backend/app/database/db_item.py
+++ b/backend/app/database/db_item.py
@@ -2,7 +2,7 @@
 from app.models import Item
 from bson import ObjectId
 from fastapi import HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from app.database.db_connection import Database
 
 
@@ -15,6 +15,8 @@ async def create_item(item: Item):
     try:
         await item.insert()
         return item
+    except ValidationError as ve:
+        raise HTTPException(status_code=422, detail=ve.errors())
     except Exception as e:
         raise Exception(f"Error fetching items: {str(e)}") # エラーログを出力
     finally:

--- a/backend/app/database/db_item.py
+++ b/backend/app/database/db_item.py
@@ -16,7 +16,7 @@ async def create_item(item: Item):
         await item.insert()
         return item
     except Exception as e:
-        print(f"Error occurred: {e}")  # エラーログを出力
+        raise Exception(f"Error fetching items: {str(e)}") # エラーログを出力
     finally:
         await db.disconnect()  # 接続を切断
 
@@ -27,14 +27,7 @@ async def get_items():
         items = await Item.find_all().to_list()
         return items
     except Exception as e:
-        raise Exception(f"Error fetching items: {str(e)}")  # エラーログを出力
+        raise Exception(f"Error fetching items: {str(e)}") 
     finally:
         await db.disconnect()  # 接続を切断
 
-# 指定したユーザーの独自データ（カスタムアイテム等すべての詳細を含む）を取得する
-async def get_user_specific_data(user_id: str):
-    try:
-        user_specific_data = await UserSpecificData.find_one({"user_id": ObjectId(user_id)})
-        return user_specific_data
-    except Exception as e:
-        raise Exception(f"Error fetching user specific data: {str(e)}")  # エラーログを出力

--- a/backend/app/database/db_item.py
+++ b/backend/app/database/db_item.py
@@ -19,3 +19,14 @@ async def create_item(item: Item):
         print(f"Error occurred: {e}")  # エラーログを出力
     finally:
         await db.disconnect()  # 接続を切断
+
+# すべてのアイテム（詳細含む）を取得する
+async def get_items():
+    await db.connect()
+    try:
+        items = await Item.find_all().to_list()
+        return items
+    except Exception as e:
+        print(f"Error occurred: {e}")  # エラーログを出力
+    finally:
+        await db.disconnect()  # 接続を切断

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from fastapi.responses import JSONResponse
 
 from app.init_schema import init_schema
 from app.api.user import router as user_router  # ユーザー用のルーターをインポート
+from app.api.item import router as item_router  # アイテム用のルーターをインポート
 
 
 @asynccontextmanager
@@ -30,3 +31,4 @@ async def error_handler(request: Request, exc: RequestValidationError):
 
 # ルーター追加
 app.include_router(user_router)  # ユーザー関連のルーターを追加
+app.include_router(item_router)  # アイテム関連のルーターを追加

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,12 +22,12 @@ async def lifespan(app: FastAPI):
 app = FastAPI(lifespan=lifespan)
 
 
-# ValidationErrorでの422エラーのレスポンス変更
-@app.exception_handler(RequestValidationError)
-async def error_handler(request: Request, exc: RequestValidationError):
-    return JSONResponse(
-        content={"detail": "There was an error in your input. Please"}, status_code=status.HTTP_422_UNPROCESSABLE_ENTITY
-    )
+# # ValidationErrorでの422エラーのレスポンス変更
+# @app.exception_handler(RequestValidationError)
+# async def error_handler(request: Request, exc: RequestValidationError):
+#     return JSONResponse(
+#         content={"detail": "There was an error in your input. Please"}, status_code=status.HTTP_422_UNPROCESSABLE_ENTITY
+#     )
 
 # ルーター追加
 app.include_router(user_router)  # ユーザー関連のルーターを追加

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -40,8 +40,8 @@ class Item(DocumentWithConfig):
     item_series: Optional[ObjectId] = None # series_id
     item_character: Optional[ObjectId] = None # character_id
     category: Optional[ObjectId] = None # category_id
-    tags: Optional[list[str]] = Field(default_factory=list)
-    jan_code: Optional[str] = None
+    tags: Optional[List[str]] = Field(default_factory=list)
+    jan_code: Optional[str] = Indexed(unique=True), None
     release_date: Optional[date] = None
     retailers: Optional[List[str]] = Field(default_factory=list)
     user_data: Optional[List[ObjectId]] = Field(default_factory=list) # user_specific_data_id

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -57,6 +57,9 @@ class ContentCatalog(DocumentWithConfig):
     characters: Optional[List["Character"]] = Field(default_factory=list)
     series_characters: Optional[List["SeriesCharacter"]] = Field(default_factory=list)
 
+    class Settings:
+        name = "content_catalogs" 
+
 # categories
 class Category(DocumentWithConfig):
     _id: ObjectId


### PR DESCRIPTION
### グッズ登録機能追加しました

**ユーザー独自データとの連携は現時点では加味せず、ベーシックな登録機能です。**
item_name重複登録回避
jan_code入力制限と重複登録回避

**今回は見送り、追って実装予定**
ログインユーザーのみが作成可
登録時のseries&characterのペアをseries_charactersに登録
登録者のuser_specific_data_idをItemコレクションのuser_dataに追加、同時にitem_idを登録者のUserSpecificDataコレクションのcustom_itemsに追加

**※models.py 少し修正しました**
コレクション名変更　ContentCatalog　→ content_catalog
Itemのjan_codeフィールドをuniqueに設定しました

