### PR TITLE
各種一覧表示機能追加

### DIFF
--- a/backend/app/api/content_catalog.py
+++ b/backend/app/api/content_catalog.py
@@ -205,29 +205,25 @@ async def get_filterd_characters(series_id: str):
             )
         # キャラクターIDをリスト化
         character_ids = [character.character_id for character in series_characters]
-        print(character_ids)
         # キャラクター詳細情報（キャラクター名）を取得
         characters_with_name = await get_all_characters()
-        print(characters_with_name)
-        # キャラクター情報をキャラクターIDでフィルタリングし辞書形式に整形
+        # キャラクター情報をキャラクターIDでフィルタリング
+        filtered_characters = [
+            character for character in characters_with_name
+            if character.id in character_ids
+        ]
+        # あいうえお順にソート
+        sorted_characters = sorted(filtered_characters, key=lambda character: character.character_name)
+        # 辞書形式に変換
         characters_dict = {
             str(character.id): character.character_name
-            for character in characters_with_name
-            if character.id in character_ids
+            for character in sorted_characters
         }
-        sorted_characters = dict(sorted(characters_dict.items(), key=lambda item: item[1]))
-        return sorted_characters
+
+        return characters_dict
 
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Error fetching sorted characters by series_id: {str(e)}"
         )
-
-# 作品名で絞った
-# キャラ一覧取得
-# (一覧ページ用)
-# GET	/api/series
-# /{series_id}
-# /characters/page/{current_page}?	
-

--- a/backend/app/database/db_content_catalog.py
+++ b/backend/app/database/db_content_catalog.py
@@ -62,7 +62,7 @@ async def create_category(category_name: str):
         )
 
 # すべてのグッズジャンル（詳細を含む）を取得する
-async def get_categories():
+async def get_all_categories():
     try:
         content_catalog = await get_content_catalog()
         if content_catalog:
@@ -98,7 +98,7 @@ async def create_series(series_name: str):
         )
     
 # すべての作品（詳細を含む）を取得する
-async def get_series():
+async def get_all_series():
     try:
         content_catalog = await get_content_catalog()
         if content_catalog:
@@ -133,7 +133,7 @@ async def create_character(character_name: str):
         )
     
 # すべてのキャラクター（詳細含む）を取得する
-async def get_characters():
+async def get_all_characters():
     try:
         content_catalog = await get_content_catalog()
         if content_catalog:
@@ -142,15 +142,6 @@ async def get_characters():
     except Exception as e:
         raise Exception(f"Error fetching characters: {str(e)}") 
 
-# すべての作品＆キャラクターの組み合わせを取得する
-async def get_series_characters():
-    try:
-        content_catalog = await get_content_catalog()
-        if content_catalog:
-            return content_catalog.series_characters
-        return None
-    except Exception as e:
-        raise Exception(f"Error fetching series_characters: {str(e)}") 
 
 # 新しい作品＆キャラクターの組み合わせを作成する
 async def create_series_character(series_id: ObjectId, character_id: ObjectId):
@@ -179,3 +170,34 @@ async def create_series_character(series_id: ObjectId, character_id: ObjectId):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An unexpected error occurd while creating the series_character."
         )
+    
+
+# すべての作品＆キャラクターの組み合わせを取得する
+async def get_all_series_characters():
+    try:
+        content_catalog = await get_content_catalog()
+        if content_catalog:
+            return content_catalog.series_characters
+        return None
+    except Exception as e:
+        raise Exception(f"Error fetching series_characters: {str(e)}") 
+    
+    
+# 指定した作品またはキャラクターに関連している相手方の名前一覧を取得
+async def get_series_characters(series_id: str):
+    try:
+        content_catalog = await get_content_catalog()
+        if content_catalog:
+            filtered_characters = [
+                character for character in content_catalog.series_characters 
+                if character.series_id == ObjectId(series_id)
+            ]
+            return filtered_characters
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, 
+            detail="No characters found for this series")
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error fetching filtered characters by series_id: {str(e)}"
+            ) 


### PR DESCRIPTION
### 各種一覧取得・表示機能追加
前回間違えてプルリクしてしまっていた３つに加え、もう一つの一覧表示機能をアップしました。

　・ログインユーザーのみ操作可能
　・独自データの反映

については、今回未実装、追って対応予定です

**グッズジャンル（カテゴリー）一覧取得**
　登録の新しい順にソート
**作品名一覧取得(検索用)** 
　登録の新しい順にソート
**作品名一覧取得(一覧ページ用)**
　登録の新しい順にソート
　テストしやすいように、１ページに２つ表示としています

**作品名で絞ったキャラ一覧取得(検索用)**
　こちらはあいうえお順にソートしてみましたが、やはり新しい順の方が良いということでしたらお知らせください

ソートについては、検索用の方、ずらっとたくさん並ぶ方は、あいうえお順の方が探しやすいかなとも思っています。