### PR TITLE
UPDATE グッズ詳細取得 独自データ対応

### DIFF
--- a/backend/app/api/item.py
+++ b/backend/app/api/item.py
@@ -150,7 +150,7 @@ async def get_item_details(item_id: str):
             custom_item = next((ci for ci in user_specific_data.custom_items if ci.item_id == ObjectId(item_id)), None)
             print(custom_item)
 
-        # カスタム情報を取得
+        # 独自名を取得
         custom_series_name = await get_custom_series_name(user_specific_data, item.item_series) if user_specific_data else None
         custom_character_name = await get_custom_character_name(user_specific_data, item.item_character) if user_specific_data else None
         custom_category_name = await get_custom_category_name(user_specific_data, item.category) if user_specific_data else None
@@ -158,14 +158,15 @@ async def get_item_details(item_id: str):
 
         if custom_item:
             response = {
-                "custom_item_name": custom_item.custom_item_name,
-                "custom_item_series_name": custom_series_name,
-                "custom_item_character_name": custom_character_name,
-                "custom_item_category_name": custom_category_name,
-                "custom_item_tags": custom_item.custom_item_tags,
+                "item_name": custom_item.custom_item_name,
+                "series_name": custom_series_name,
+                "character_name": custom_character_name,
+                "category_name": custom_category_name,
+                "tags": custom_item.custom_item_tags,
                 "jan_code": item.jan_code,
                 "release_date": item.release_date,
-                "custom_item_retailer": custom_item.custom_item_retailer
+                "retailer": custom_item.custom_item_retailer,
+                "own_status": custom_item.own_status
             }
         else:
             # 共有の名前を取得
@@ -176,13 +177,14 @@ async def get_item_details(item_id: str):
 
             response = {
                 "item_name": item.item_name,
-                "series_name": series_name,
-                "character_name": character_name,
-                "category_name": category_name,
+                "series_name": custom_series_name if custom_series_name else series_name,
+                "character_name": custom_character_name if custom_character_name else character_name,
+                "category_name": custom_category_name if custom_category_name else category_name,
                 "tags": item.tags,
                 "jan_code": item.jan_code,
                 "release_date": item.release_date,
-                "retailers": item.retailers
+                "retailers": item.retailers,
+                "own_status": "false"
             }
         return response
     

--- a/backend/app/database/db_content_catalog.py
+++ b/backend/app/database/db_content_catalog.py
@@ -112,12 +112,12 @@ async def create_character(character_name: str):
     try:
         content_catalog = await get_content_catalog()
         # 既存のseries_nameと重複を確認
-        for existing_character in content_catalog.characters:
-            if existing_character.character_name == character_name:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Character with the same name already exists."
-                )            
+        # for existing_character in content_catalog.characters:
+        #     if existing_character.character_name == character_name:
+        #         raise HTTPException(
+        #             status_code=status.HTTP_400_BAD_REQUEST,
+        #             detail="Character with the same name already exists."
+                # )            
         # 新しいキャラクターを追加
         new_character = Character(_id=ObjectId(), character_name=character_name)
         content_catalog.characters.append(new_character)

--- a/backend/app/init_schema.py
+++ b/backend/app/init_schema.py
@@ -45,12 +45,12 @@ async def init_schema(database):
             custom_items=[
                 CustomItem(
                     _id=ObjectId(),
-                    item_id=ObjectId("6728433b3bdeccb81751047a"),
+                    item_id=ObjectId("6736b102d2bffe77f23d75db"),
                     custom_item_images=[ObjectId("61f5f484a2d21a1d4cf1b0e6")],
                     custom_item_name="My Test Custom Item",
-                    custom_item_series_name=ObjectId("672840afd9dc1d815343faa6"),
-                    custom_item_character_name=ObjectId("672840afd9dc1d815343faa7"),
-                    custom_item_category_name=ObjectId("67283c42caab231ed09c55a4"),
+                    custom_item_series_name=ObjectId("6739c48fc49c15be3d1dccb7"),
+                    custom_item_character_name=ObjectId("6739c48fc49c15be3d1dccb8"),
+                    custom_item_category_name=ObjectId("6739c48fc49c15be3d1dccb6"),
                     custom_item_tags=["Mytag1", "Mytag2"],
                     custom_item_retailer="My Test Local Store",
                     custom_item_notes="This is a personal note.",

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -73,7 +73,7 @@ class Series(DocumentWithConfig):
 # characters
 class Character(DocumentWithConfig):
     _id: ObjectId
-    character_name: str = Indexed(unique=True)  # キャラクター名
+    character_name: str = Optional[str]
 
 # series_characters
 class SeriesCharacter(DocumentWithConfig):


### PR DESCRIPTION
### UPDATEグッズ詳細取得　
@router.get("/api/items/{item_id}")

**ユーザー独自データに対応しました。**

暫定的に　user_id を初期挿入データのものにしています
user_id = ObjectId("507f1f77bcf86cd799439011")

**未対応、追って対応予定**
ログインユーザーのみの操作許可
JWTからのuser_id取得

テストパターン網羅できていませんので、不具合見つけましたらお知らせください。

---------------------------------------------------------------
テスト例

できれば真っ新な（init直後の）データベースではじめてください。

1.　初期挿入のユーザーを　ユーザーA　とします。

2.　新しいユーザーを新規登録　ユーザーB　とします。ユーザーIDを控えます。

3.　新しい作品＆キャラクターを登録して、その作品IDとキャラクターIDを控えます

```
{
  "series_name": "共有作品名",
  "is_new_series": true,
  "character_name": "共有キャラ名",
  "is_new_character": true
}
```
4.　3で控えたIDを使って新しいアイテムを登録します。アイテムBとします。アイテムIDを控えます
ちなみに、このcategory_idはユーザーAの独自データで独自名が設定されているものです
```
{
  "item_name": "共有アイテムB",
  "item_series": "取得したシリーズID",
  "item_character": "取得したキャラクターID",
  "category": "6736ae992ca618e77d720a9f",
  "tags": [
    "共有タグ"
  ],
  "jan_code": "22222222",
  "release_date": "2024-10-10",
  "retailers": [
    "共有shop"
  ]
}
```
5.　アイテム　**6736b102d2bffe77f23d75db**　の情報を表示してみます。
ユーザーAがcustom_itemとして所持しているものなので、独自データが表示されます

6.　ユーザーAがアイテムB　の情報を表示してみます。
custom_itemとしては持っていませんが、category_id の情報を独自データに持っているため、
category_name だけ、独自名が表示されます。

6.　ユーザー設定を変更します。

item.py
グッズ詳細取得
@router.get("/api/items/{item_id}")
async def get_item_details(item_id: str):

    user_id = ObjectId("ユーザーBのuser_id") 

7.　ユーザーBがアイテムB(取得したアイテムBのitem_id)を表示してみます。
独自データを何も持っていないので、共有データが表示されます。
アイテム 6736b102d2bffe77f23d75db　を表示した時も同様です
