### PR TITLE
全体に認証追加

### DIFF
--- a/backend/app/api/content_catalog.py
+++ b/backend/app/api/content_catalog.py
@@ -1,12 +1,13 @@
 # backend/app/api/content_catalog.py
 from typing import Optional
+from app.api.user import get_current_user
 from app.database.db_content_catalog import create_character, create_series, create_series_character, get_all_categories, get_all_characters, get_all_series, create_category, get_series_characters
 from pydantic import BaseModel, field_validator,  model_validator
 from bson import ObjectId
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status
 
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(get_current_user)])
 
 # グッズジャンル（カテゴリー）登録
 @router.post("/api/categories")

--- a/backend/app/api/item.py
+++ b/backend/app/api/item.py
@@ -1,17 +1,18 @@
 # backend/app/api/item.py
 from typing import List, Optional
 from app.models import Item, UserSpecificData
+from app.api.user import get_current_user
 from app.database.db_item import create_item, existing_item_check, get_item, get_all_items
 from app.database.db_content_catalog import character_name_partial_match, get_category_name, get_character_name, get_series_name, series_name_partial_match
 from pydantic import BaseModel, field_validator, ValidationError, Field, StringConstraints
 from datetime import date, timedelta
 from bson import ObjectId
-from fastapi import APIRouter, HTTPException, status, Query
+from fastapi import APIRouter, Depends, HTTPException, status, Query
 from beanie import Indexed
 import re, calendar
 from datetime import datetime
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(get_current_user)])
 
 class ItemRequest(BaseModel):    
     item_images: Optional[List[str]] = Field(default_factory=list) # image_idのリスト

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,12 +1,13 @@
 # backend/app/main.py
 from contextlib import asynccontextmanager
 from app.database.db_connection import Database
-from fastapi import FastAPI, Request, status, HTTPException
+from fastapi import FastAPI, Request, status, HTTPException, Depends
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
 
 from app.init_schema import init_schema
+from app.api.user import get_current_user
 from app.api.user import router as user_router  # ユーザー用のルーターをインポート
 from app.api.item import router as item_router  # アイテム用のルーターをインポート
 from app.api.content_catalog import router as content_catalog_router  # ContentCatalog用のルーターをインポート
@@ -30,6 +31,23 @@ app = FastAPI(lifespan=lifespan)
 #     return JSONResponse(
 #         content={"detail": "There was an error in your input. Please"}, status_code=status.HTTP_422_UNPROCESSABLE_ENTITY
 #     )
+
+# tokenデコードしてuser_id取得
+# def get_current_user(token: str = Depends(oauth2_scheme)):
+#     credentials_exception = HTTPException(
+#         status_code=401,
+#         detail="Could not validate credentials",
+#         headers={"WWW-Authenticate": "Bearer"},
+#     )
+#     try:
+#         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+#         user_id: str = payload.get("sub")
+        
+#         if user_id is None:
+#             raise credentials_exception
+#     except InvalidTokenError:
+#         raise credentials_exception
+#     return user_id
 
 # ルーター追加
 app.include_router(user_router)  # ユーザー関連のルーターを追加


### PR DESCRIPTION
login、signup以外にtokenによる認証が入るようにしました。
合わせてtokenからuser_idが取れるようになるので
user_idが欲しい場合は
```
user_id: str = Depends(get_current_user)
```
を記載してください。

**取得するuser_idはstr型でObjectID型ではないのでご注意を！**

image.pyは記載済みですので参考になればと思います。


＜試したこと＞
サインアップでユーザーを2人作成
それぞれのID、アドレス、パスワードを控える

OpneAPIの画面(http://localhost:8000/docs)にて、右上の緑のアイコンをクリック
そこでusername、passwordの欄にユーザー1のアドレス、パスワードを入力して 「authorize」をクリック
　仕様でusernameという変数名しかダメらしいです
　他は空欄で大丈夫なはず
みどりのボタンの鍵のアイコンが閉じるはず

token-testエンドポイントでExecuteしてもらって、先ほど控えたユーザー1のIDが表示される

試しに背景画像を登録してダウンロード
右上の緑のボタンから「Logout」

同じく緑のボタンからユーザー2でログイン
同様にtoken-testエンドポイントでExecuteしてもらって、先ほど控えたユーザー2のIDが表示されるはず

背景画像をダウンロードしようとして「無い」って怒られる
背景画像を登録してダウンロードすると、今登録した画像がダウンロードできる
