### PR TITLE
items/createにて 主要な機能を作成・追加

### DIFF
--- a/frontend/src/app/api/categories/route.ts
+++ b/frontend/src/app/api/categories/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest } from "next/server"
+
+const backendUrl = process.env.BACKEND_API_URL
+
+export async function POST(
+  request: NextRequest,
+) {
+  const formData = await request.formData()
+  const searchParams = new URLSearchParams(formData)
+  const requestUrl = `${ backendUrl }categories?${ searchParams }`
+  const response = await fetch(
+    requestUrl,
+    {
+      method: "POST",
+    }
+  )
+
+  return response
+}

--- a/frontend/src/app/api/items/create/route.ts
+++ b/frontend/src/app/api/items/create/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest } from "next/server"
+
+const backendUrl = process.env.BACKEND_API_URL
+
+export async function GET(
+  request: NextRequest,
+) {
+  // これはapi/items/createにリクエストとしてきたクエリを受け取る
+  const searchParams = request.nextUrl.searchParams
+  const endpoint = searchParams.get("endpoint")
+  if (!endpoint) console.error("リクエストを処理できません")
+
+  const seriesId = searchParams.get("seriesId")
+  const onlyCharacterEndpoint = seriesId ? `series/${ seriesId }/` : ""
+  const requestUrl = `${ backendUrl }${ onlyCharacterEndpoint }${ endpoint }`
+
+  const response = await fetch(requestUrl)
+  // エラー処理が必要(空検索は対応済み サーバーエラーなど 未定)
+  return response
+}
+
+export async function POST(
+  request: NextRequest,
+) {
+  const formData = await request.formData()
+  const requestUrl = `${ backendUrl }items`
+  const json = JSON.stringify(Object.fromEntries(formData.entries()))
+
+  const response = await fetch(
+    requestUrl,
+    {
+      headers: {"Content-Type":"application/json"},
+      method: "POST",
+      body: json
+    }
+  )
+
+  return response
+}

--- a/frontend/src/app/api/series-characters/route.ts
+++ b/frontend/src/app/api/series-characters/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest } from "next/server"
+
+const backendUrl = process.env.BACKEND_API_URL
+
+export async function POST(
+  request: NextRequest,
+) {
+  const formData = await request.formData()
+  // booleanに変換
+  const isNewSeries = formData.get("is_new_series") === "true"
+  const isNewCharacter = formData.get("is_new_character") === "true"
+  const object = Object.fromEntries(formData.entries())
+  object["is_new_series"] = isNewSeries
+  object["is_new_character"] = isNewCharacter
+
+  const json = JSON.stringify(object)
+  const requestUrl = `${ backendUrl }series-characters`
+  const response = await fetch(
+    requestUrl,
+    {
+      headers: {"Content-Type":"application/json"},
+      method: "POST",
+      body: json
+    }
+  )
+
+  return response
+}

--- a/frontend/src/app/items/create/page.tsx
+++ b/frontend/src/app/items/create/page.tsx
@@ -1,35 +1,109 @@
+"use client"
+
 import InputButton from "@/components/InputButton"
 import MonitorLayout from "@/components/MonitorLayout"
 import TopButton from "@/components/TopButton"
-import ImageUploadForm from "@/features/common/ImageUploadForm"
+import { BACKEND_ITEM_KEYS as keys } from "@/constants"
+import ErrorModal from "@/features/common/errorModal/ErrorModal"
+import UploadItemsForm from "@/features/common/UploadItemsForm"
 import ClickAndInputButton from "@/features/routes/create/components/ClickAndInputButton"
+import CreateCharacterForm from "@/features/routes/create/components/CreateCharacterForm"
+import CreateForm from "@/features/routes/create/components/CreateForm"
+import CreateSeriesAndCharacterForm from "@/features/routes/create/components/CreateSeriesAndCharacterForm"
+import SelectModal from "@/features/routes/create/components/SelectModal"
+import ModalData from "@/features/routes/create/ModalData"
+import { useState } from "react"
 
 const ItemCreatePage = () => {
+  const [seriesList, setSeriesList] =
+    useState<ModalData>({data: false, isShow: false, choiced: ""})
+  const [charactersList, setChractersList] =
+    useState<ModalData>({data: false, isShow: false, choiced: ""})
+  const [categoriesList, setCategoriesList] =
+    useState<ModalData>({data: false, isShow: false, choiced: ""})
+  const [error, setError] = useState<boolean>(false)
   return (
-    <MonitorLayout
-      headerContent={ <TopButton/> }
-      viewContent
-      naviContent={
-        <>
-          <ImageUploadForm
-            buttonText="登録!"
-            formId="item_create"
-            uploadImageText="アップロード画像を選択"
-            addClass="h-full flex flex-col justify-around Y-tab:grid Y-tab:grid-cols-2 Y-tab:gap-4"
-          >
-            <ClickAndInputButton inputName="series_name">作品名</ClickAndInputButton>
-            <ClickAndInputButton inputName="character_name">キャラ名</ClickAndInputButton>
-            <InputButton placeholder="商品名"/>
-            <InputButton placeholder="タグ"/>
-            <ClickAndInputButton inputName="category_name">グッズカテゴリー</ClickAndInputButton>
-            <InputButton placeholder="JANコード"/>
-            <InputButton placeholder="発売日"/>
-            <InputButton placeholder="購入場所"/>
-          </ImageUploadForm>
-        </>
-      }
-      footerContent
-    />
+    <>
+      <MonitorLayout
+        headerContent={ <TopButton/> }
+        viewContent
+        naviContent={
+          <>
+            <UploadItemsForm
+              setError={ setError }
+            >
+              <ClickAndInputButton
+                endpoint="series"
+                state={ seriesList }
+                handleSetState={ setSeriesList }
+                inputName={ keys.series }
+                placeholder="作品名"
+              />
+              <ClickAndInputButton
+                endpoint="characters"
+                state={ charactersList }
+                handleSetState={ setChractersList }
+                inputName={ keys.character }
+                seriesList={ seriesList }
+                placeholder="キャラ名"
+              />
+              <InputButton inputName={ keys.name } placeholder="商品名" required/>
+              <InputButton inputName={ keys.tags } placeholder="タグ"/>
+              <ClickAndInputButton
+                endpoint="category"
+                state={ categoriesList }
+                handleSetState={ setCategoriesList }
+                inputName={ keys.category }
+                placeholder="グッズカテゴリー"
+              />
+              <InputButton inputName={ keys.janCode } pattern="[a-zA-Z0-9]*" placeholder="JANコード"/>
+              <InputButton inputName={ keys.releaseDate } type="date" placeholder="発売日"/>
+              <InputButton inputName={ keys.retailers } placeholder="購入場所"/>
+            </UploadItemsForm>
+          </>
+        }
+        footerContent
+      />
+      <SelectModal
+        state={ seriesList }
+        setState={ setSeriesList }
+        listName="作品名"
+        charactersList={ charactersList }
+        setChractersList={ setChractersList }
+      >
+        <CreateSeriesAndCharacterForm
+          charactersList={ charactersList }
+          setCharacterList={ setChractersList }
+          setError={ setError }
+        />
+      </SelectModal>
+      <SelectModal
+        state={ charactersList }
+        setState={ setChractersList }
+        listName="キャラクター名"
+      >
+        <CreateCharacterForm
+          charactersList={ charactersList }
+          setChractersList={ setChractersList }
+          setError={ setError }
+          choiced={ seriesList.choiced }
+        />
+      </SelectModal>
+      <SelectModal
+        state={ categoriesList }
+        setState={ setCategoriesList }
+        listName="カテゴリー名"
+      >
+        <CreateForm
+          inputName="category_name"
+          categoriesList={ categoriesList }
+          setCategoriesList={ setCategoriesList }
+          endpoint="categories"
+          setError={ setError }
+        />
+      </SelectModal>
+      <ErrorModal error={ error } setError={ setError }/>
+    </>
   )
 }
 

--- a/frontend/src/app/items/page.tsx
+++ b/frontend/src/app/items/page.tsx
@@ -65,7 +65,7 @@ const ItemsPage = () => {
             <InputButton type="search" inputName="character_name" placeholder="キャラ名"/>
             <InputButton type="search" inputName="item_name" placeholder="商品名"/>
             <InputButton type="search" inputName="tags" placeholder="タグ"/>
-            <InputButton type="text" inputName="category_id" placeholder="グッズカテゴリー"/>
+            <InputButton type="search" inputName="category_id" placeholder="グッズカテゴリー"/>
             <InputButton type="search" inputName="jan_code" pattern="[a-zA-Z0-9]*" placeholder="JANコード"/>
             <InputButton type="date" inputName="release_date" placeholder="発売日"/>
             <InputButton type="search" inputName="retailers" placeholder="購入場所"/>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -23,7 +23,7 @@ const RootLayout = ({
     <html lang="ja">
       <body className={ hachiMaruPop.className }>
         <main //画面のサイズを設定
-          className="max-w-screen-xl mx-auto w-full h-screen min-w-[352px] min-h-[600px] X-mob:min-w-[600px] X-mob:min-h-[352px]"
+          className="max-w-screen-xl mx-auto w-full h-screen min-w-[352px] min-h-[600px] X-mob:min-w-[600px] X-mob:min-h-[352px] relative"
         >
           { children }
         </main>

--- a/frontend/src/app/series/[seriesId]/page.tsx
+++ b/frontend/src/app/series/[seriesId]/page.tsx
@@ -1,11 +1,14 @@
+"use client"
+
 import MonitorLayout from "@/components/MonitorLayout"
 import TextLinkButton from "@/components/TextLinkButton"
 import TextViewButton from "@/components/TextViewButton"
 import TopButton from "@/components/TopButton"
 import PagenationListContainer from "@/features/common/pagenation/components/PagenationListContainer"
 import PagenationListItem from "@/features/common/pagenation/components/PagenationListItem"
-import PagenationNavi from "@/features/common/pagenation/components/PagenationNavi"
 import PagenationNaviContainer from "@/features/common/pagenation/components/PagenationNaviContainer"
+import PageState from "@/features/common/pagenation/PageState"
+import { useState } from "react"
 
 // const CharactersPage = ({
 const CharactersPage = async (
@@ -15,6 +18,7 @@ const CharactersPage = async (
     }>
   }
 ) => {
+  const [pageState, setPageState] = useState<PageState>({currentPage: 1, maxPage: 1})
   const { seriesId } = await context.params
   const viewContent = (
     <>
@@ -35,10 +39,10 @@ const CharactersPage = async (
           </TextLinkButton>
         </PagenationListItem>
       </PagenationListContainer>
-      <PagenationNaviContainer>
-        <PagenationNavi href={`/series/${ seriesId }?page=1`}>1</PagenationNavi>
-        <PagenationNavi href={`/series/${ seriesId }?page=2`}>2</PagenationNavi>
-      </PagenationNaviContainer>
+      <PagenationNaviContainer
+        pageState={ pageState }
+        handleSetPageState={ setPageState }
+      />
     </>
   )
   return (

--- a/frontend/src/app/series/page.tsx
+++ b/frontend/src/app/series/page.tsx
@@ -1,13 +1,17 @@
+"use client"
+
 import MonitorLayout from "@/components/MonitorLayout"
 import TextLinkButton from "@/components/TextLinkButton"
 import TextViewButton from "@/components/TextViewButton"
 import TopButton from "@/components/TopButton"
 import PagenationListContainer from "@/features/common/pagenation/components/PagenationListContainer"
 import PagenationListItem from "@/features/common/pagenation/components/PagenationListItem"
-import PagenationNavi from "@/features/common/pagenation/components/PagenationNavi"
 import PagenationNaviContainer from "@/features/common/pagenation/components/PagenationNaviContainer"
+import PageState from "@/features/common/pagenation/PageState"
+import { useState } from "react"
 
 const SeriesPage = () => {
+  const [pageState, setPageState] = useState<PageState>({currentPage: 1, maxPage: 1})
   const viewContent = (
     // 要素を並べて、最終行にページネーションリンクを置く
     <>
@@ -29,10 +33,10 @@ const SeriesPage = () => {
         </PagenationListItem>
       </PagenationListContainer>
 
-      <PagenationNaviContainer>
-        <PagenationNavi href="/series?page=1">1</PagenationNavi>
-        <PagenationNavi href="/series?page=2">2</PagenationNavi>
-      </PagenationNaviContainer>
+      <PagenationNaviContainer
+        pageState={ pageState }
+        handleSetPageState={ setPageState }
+      />
     </>
   )
 

--- a/frontend/src/components/InputButton.tsx
+++ b/frontend/src/components/InputButton.tsx
@@ -5,15 +5,17 @@ const InputButton = ({
   placeholder = "",
   defaultValue = "",
   inputName,
-  type,
+  type = "text",
   pattern,
+  required = false,
 }: Readonly<{
   addClass?: string
   placeholder?: string
   defaultValue?: string
   inputName: string
-  type: string
+  type?: string
   pattern?: string
+  required?: boolean
 }>) => {
   const baseClass = "block bg-my-light-green w-60 h-[40px] rounded-3xl text-center mx-auto mt-4 py-2"
   const className = concatClassName(baseClass, addClass)
@@ -26,6 +28,7 @@ const InputButton = ({
       defaultValue={ defaultValue }
       pattern={ pattern || undefined }
       maxLength={30}
+      required={ required }
     />
   )
 }

--- a/frontend/src/components/TopNaviContent.tsx
+++ b/frontend/src/components/TopNaviContent.tsx
@@ -19,7 +19,7 @@ const TopNaviContent = () => {
           formId="top-page-form"
           buttonText="画像送信"
           uploadImageText="背景画像を設定する"
-        ></ImageUploadForm>
+        />
         <BackgroundImageResetButton/>
       </div>
     </>

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,0 +1,11 @@
+export const BACKEND_ITEM_KEYS = {
+  series: "item_series",
+  character: "item_character",
+  name: "item_name",
+  tags: "tags",
+  category: "category",
+  janCode: "jan_code",
+  releaseDate: "release_date",
+  retailers: "retailers",
+  image: "item_images",
+}

--- a/frontend/src/features/common/ImageUploadForm.tsx
+++ b/frontend/src/features/common/ImageUploadForm.tsx
@@ -19,7 +19,6 @@ const ImageUploadForm = ({
     <form
       autoComplete="off"
       className={ className }
-      encType="multipart/form-data"
       id={ formId }
       name={ formId }
       // action

--- a/frontend/src/features/common/UploadItemsForm.tsx
+++ b/frontend/src/features/common/UploadItemsForm.tsx
@@ -1,0 +1,60 @@
+import { BACKEND_ITEM_KEYS as keys } from "@/constants"
+import sendFormAction from "@/utils/sendFormAction"
+import { redirect } from "next/navigation"
+
+const UploadItemsForm = ({
+  children,
+  setError,
+}: Readonly<{
+  children: React.ReactNode
+  setError: React.Dispatch<React.SetStateAction<boolean>>
+}>) => {
+  const className = "mx-auto flex flex-col h-full justify-around Y-tab:grid Y-tab:grid-cols-2 Y-tab:gap-4"
+  const uploadImageText = "アップロード画像を選択"
+  const formId = "item-create"
+  return (
+    <form
+      autoComplete="off"
+      className={ className }
+      id={ formId }
+      name={ formId }
+      action={
+        async formData => {
+          const endpoint = "items/create"
+          const requires = [keys.series, keys.character, keys.name, keys.category]
+
+          const result = await sendFormAction(formData, endpoint, requires)
+          if (!result) {// サーバーエラー・重複などで作成に失敗した場合
+            setError(true)
+          } else {
+            redirect("/")
+          }
+        }
+      }
+    >
+      { children }
+      <div>
+        <label
+          htmlFor={ formId }
+          className="leading-tight bg-my-light-green w-60 block mx-auto rounded-lg mt-4"
+        >
+          { uploadImageText }
+        </label>
+        <input
+          accept="image/*"
+          type="file"
+          id={ formId }
+          className="file:opacity-0 file:block file:bg-my-orange file:h-0 file:border-0 h-[40px] mx-auto rounded-[40px] pl-10 bg-my-orange leading-normal cursor-pointer w-60"
+        />
+      </div>
+      <button
+        className="block h-[40px] w-60 rounded-3xl bg-my-orange mx-auto mt-4"
+        type="submit"
+      >
+        <p>登録!</p>
+      </button>
+    </form>
+  )
+}
+
+export default UploadItemsForm

--- a/frontend/src/features/common/errorModal/ErrorModal.tsx
+++ b/frontend/src/features/common/errorModal/ErrorModal.tsx
@@ -1,0 +1,22 @@
+import handleClick from "./handleClick"
+
+const ErrorModal = ({
+  error,
+  setError,
+}: Readonly<{
+  error: boolean
+  setError: React.Dispatch<React.SetStateAction<boolean>>
+}>) => {
+  const elements = !error ? null :
+    <div className="absolute w-full h-full bg-red-300 top-0 flex flex-col justify-center [&>*]:mb-4">
+      <p>処理に失敗しました</p>
+      <p>もう一度やり直してください</p>
+      <button
+        onClick={ () => handleClick(setError) }
+        className="w-48 h-10 bg-my-yellow rounded-full mx-auto"
+      >戻る</button>
+    </div>
+  return elements
+}
+
+export default ErrorModal

--- a/frontend/src/features/common/errorModal/handleClick.ts
+++ b/frontend/src/features/common/errorModal/handleClick.ts
@@ -1,0 +1,7 @@
+const handleClick = (
+  setError: React.Dispatch<React.SetStateAction<boolean>>
+) => {
+  setError(false)
+}
+
+export default handleClick

--- a/frontend/src/features/routes/create/ModalData.ts
+++ b/frontend/src/features/routes/create/ModalData.ts
@@ -1,0 +1,5 @@
+export default interface ModalData {
+  data: object | false,
+  isShow: boolean,
+  choiced: string,
+}

--- a/frontend/src/features/routes/create/SeriesCharacters.ts
+++ b/frontend/src/features/routes/create/SeriesCharacters.ts
@@ -1,0 +1,8 @@
+export default interface SeriesCharacters {
+  series_id: string,
+  series_name: string,
+  is_new_series: boolean,
+  character_id: string,
+  character_name: string,
+  is_new_character: boolean
+}

--- a/frontend/src/features/routes/create/components/ClickAndInputButton.tsx
+++ b/frontend/src/features/routes/create/components/ClickAndInputButton.tsx
@@ -1,23 +1,38 @@
-import OnClickButton from "@/features/common/OnClickButton"
+import getInputList from "../getInputList"
+import ModalData from "../ModalData"
 
 const ClickAndInputButton = ({
-  children,
-  inputName
+  endpoint,
+  state,
+  handleSetState,
+  inputName,
+  seriesList,
+  placeholder,
 }: Readonly<{
-  children: string
+  endpoint: string
+  state: ModalData
+  handleSetState: React.Dispatch<React.SetStateAction<ModalData>>
   inputName: string
+  seriesList?: ModalData
+  placeholder: string
 }>) => {
+  const naviChara = state.choiced === "" ? placeholder : state.data[state.choiced]
   return (
     <>
-      <OnClickButton
-        addClass="bg-[#5271ff] w-60 mx-auto mt-4 bg-opacity-80"
+      <button
+        className="bg-[#5271ff] w-60 mt-4 bg-opacity-80 block mx-auto w-60 h-[40px] py-2 rounded-3xl text-center"
+        onClick={ () => getInputList(endpoint, handleSetState, seriesList) }
+        type="button"
       >
-        { children }
-      </OnClickButton>
-      <input
-        className="hidden"
-        name={ inputName }
-      />
+        <input
+          className="h-[1px] w-[1px] opacity-[0.1]"
+          name={ inputName }
+          defaultValue={ state.choiced }
+          form="item-create"
+          required
+        />
+        { naviChara }
+      </button>
     </>
   )
 }

--- a/frontend/src/features/routes/create/components/CloseModalButton.tsx
+++ b/frontend/src/features/routes/create/components/CloseModalButton.tsx
@@ -1,0 +1,33 @@
+import ModalData from "../ModalData"
+import closeModal from "./closeModal"
+
+const CloseModalButton = ({
+  state,
+  setState,
+  charactersList,
+  setChractersList,
+}: Readonly<{
+  state: ModalData
+  setState: React.Dispatch<React.SetStateAction<ModalData>>
+  charactersList?: ModalData
+  setChractersList?: React.Dispatch<React.SetStateAction<ModalData>>
+}>) => {
+  return (
+    <button
+      onClick={
+        () => {
+          closeModal(state, setState)
+          if (setChractersList) closeModal(charactersList, setChractersList, true)
+        }
+      }
+      type="button"
+      className="bg-[#5271ff] w-48 h-10 opacity-4/5 rounded-full"
+    >
+      <p>
+        選択を解除して戻る
+      </p>
+    </button>
+  )
+}
+
+export default CloseModalButton

--- a/frontend/src/features/routes/create/components/CreateCharacterForm.tsx
+++ b/frontend/src/features/routes/create/components/CreateCharacterForm.tsx
@@ -1,0 +1,64 @@
+import sendFormAction from "@/utils/sendFormAction"
+import ModalData from "../ModalData"
+
+const CreateCharacterForm = ({
+  charactersList,
+  setChractersList,
+  setError,
+  choiced,
+}: Readonly<{
+  charactersList: ModalData
+  setChractersList: React.Dispatch<React.SetStateAction<ModalData>>
+  setError: React.Dispatch<React.SetStateAction<boolean>>
+  choiced: string
+}>) => {
+  return (
+    <form
+      action={
+        async formData => {
+          const endpoint = "series-characters"
+          const requires = [
+            "series_id",
+            "is_new_series",
+            "character_name",
+            "is_new_character",
+          ]
+
+          if (!formData.get(requires[2])) return// 空白アラートの関数など呼びたい
+          formData.append(requires[0], choiced)
+          formData.append(requires[1], "false")
+          formData.append(requires[3], "true")
+
+          const result = await sendFormAction(formData, endpoint, requires)
+          if (!result) {// サーバーエラー・重複などで作成に失敗した場合
+            const closedState: ModalData = {data: charactersList.data, isShow: false, choiced: charactersList.choiced}
+            setError(true)
+            setChractersList(closedState)
+          } else {
+            const newStateData = {...charactersList.data}
+            const characterId = result.character_id
+            newStateData[characterId] = formData.get("character_name")
+            const newState: ModalData = {data: newStateData, isShow: false, choiced: characterId}
+            setChractersList(newState)
+          }
+        }
+      }
+      className="flex w-full h-12 items-center justify-center"
+    >
+      <input
+        name="character_name"
+        className="bg-my-light-green h-10 rounded-xl text-center"
+        type="text"
+        placeholder="新しく作成する！"
+      />
+      <button
+        className="bg-my-orange w-40 h-10 rounded-full"
+        type="submit"
+      >
+        作成する！
+      </button>
+    </form>
+  )
+}
+
+export default CreateCharacterForm

--- a/frontend/src/features/routes/create/components/CreateForm.tsx
+++ b/frontend/src/features/routes/create/components/CreateForm.tsx
@@ -1,0 +1,53 @@
+import sendFormAction from "@/utils/sendFormAction"
+import ModalData from "../ModalData"
+
+const CreateForm = ({
+  inputName,
+  categoriesList,
+  setCategoriesList,
+  endpoint,
+  setError,
+}: Readonly<{
+  inputName: string
+  categoriesList: ModalData
+  setCategoriesList: React.Dispatch<React.SetStateAction<ModalData>>
+  endpoint: string
+  setError: React.Dispatch<React.SetStateAction<boolean>>
+}>) => {
+  return (
+    <form
+      action={
+        async formData => {
+          const result = await sendFormAction(formData, endpoint, [inputName])
+          if (!result) {// サーバーエラー・重複などで作成に失敗した場合
+            const closedState: ModalData = {data: categoriesList.data, isShow: false, choiced: categoriesList.choiced}
+            setError(true)
+            setCategoriesList(closedState)
+          } else {
+            const newStateData = {...categoriesList.data}
+            const categoryId = result.category_id
+            newStateData[categoryId] = result["category_name"]
+            const newState: ModalData = {data: newStateData, isShow: false, choiced: result["category_id"]}
+            setCategoriesList(newState)
+          }
+        }
+      }
+      className="flex w-full h-12 items-center justify-center"
+    >
+      <input
+        name={ inputName }
+        className="bg-my-light-green h-10 rounded-xl text-center"
+        type="text"
+        placeholder="新しく作成する！"
+      />
+      <button
+        className="bg-my-orange w-40 h-10 rounded-full"
+        type="submit"
+      >
+        作成する！
+      </button>
+    </form>
+  )
+}
+
+export default CreateForm

--- a/frontend/src/features/routes/create/components/CreateSeriesAndCharacterForm.tsx
+++ b/frontend/src/features/routes/create/components/CreateSeriesAndCharacterForm.tsx
@@ -1,0 +1,69 @@
+import sendFormAction from "@/utils/sendFormAction"
+import ModalData from "../ModalData"
+  
+const CreateSeriesAndCharacterForm = ({
+  charactersList,
+  setCharacterList,
+  setError,
+}: Readonly<{
+  charactersList: ModalData
+  setCharacterList: React.Dispatch<React.SetStateAction<ModalData>>
+  setError: React.Dispatch<React.SetStateAction<boolean>>
+}>) => {
+  return (
+    <form
+      action={
+        async formData => {
+          const endpoint = "series-characters"
+          const requires = [
+            "series_name",
+            "is_new_series",
+            "character_name",
+            "is_new_character",
+          ]
+
+          if (!formData.get(requires[0]) || !formData.get(requires[2])) return// 空白アラートの関数など呼びたい
+          formData.append(requires[1], "true")
+          formData.append(requires[3], "true")
+
+          const result = await sendFormAction(formData, endpoint, requires)
+          if (!result) {// サーバーエラー・重複などで作成に失敗した場合
+            const closedState: ModalData = {data: charactersList.data, isShow: false, choiced: charactersList.choiced}
+            setError(true)
+            setCharacterList(closedState)
+          } else {
+            const newStateData = {...charactersList.data}
+            const characterId = result.character_id
+            newStateData[characterId] = formData.get("character_name")
+            const newState: ModalData = {data: newStateData, isShow: false, choiced: characterId}
+            setCharacterList(newState)
+          }
+        }
+      }
+      className="w-full items-center justify-center [&>*]:mx-2 [&>*]:mb-2 X-tab:flex X-tab:h-12 Y-tab:flex Y-tab:h-12"
+    >
+      <input
+        name="series_name"
+        className="bg-my-light-green h-10 rounded-xl text-center"
+        type="text"
+        placeholder="新しく作成: 作品名"
+        required
+      />
+      <input
+        name="character_name"
+        className="bg-my-light-green h-10 rounded-xl text-center"
+        type="text"
+        placeholder="新しく作成: キャラクター名"
+        required
+      />
+      <button
+        className="bg-my-orange w-40 h-10 rounded-full"
+        type="submit"
+      >
+        作成する！
+      </button>
+    </form>
+  )
+}
+
+export default CreateSeriesAndCharacterForm

--- a/frontend/src/features/routes/create/components/SelectInputButton.tsx
+++ b/frontend/src/features/routes/create/components/SelectInputButton.tsx
@@ -1,0 +1,27 @@
+import ModalData from "../ModalData"
+import setInputList from "../setInputList"
+
+const SelectInputButton = ({
+  id,
+  value,
+  state,
+  setState,
+}: Readonly<{
+  id: string
+  value: string
+  state: ModalData
+  setState: React.Dispatch<React.SetStateAction<ModalData>>
+}>) => {
+  return (
+    <button
+      id={ id }
+      onClick={ () => setInputList(id, state, setState) }
+      type="button"
+      className="block mx-auto rounded-full w-60 h-8 bg-my-yellow mb-2"
+    >
+      { value }
+    </button>
+  )
+}
+
+export default SelectInputButton

--- a/frontend/src/features/routes/create/components/SelectModal.tsx
+++ b/frontend/src/features/routes/create/components/SelectModal.tsx
@@ -1,0 +1,44 @@
+import ModalData from "../ModalData"
+import CloseModalButton from "./CloseModalButton"
+import SelectInputButton from "./SelectInputButton"
+
+const SelectModal = ({
+  children,
+  state,
+  setState,
+  listName,
+  charactersList,
+  setChractersList,
+}: Readonly<{
+  children: React.ReactNode
+  state: ModalData
+  setState: React.Dispatch<React.SetStateAction<ModalData>>
+  listName: string
+  charactersList?: ModalData
+  setChractersList?: React.Dispatch<React.SetStateAction<ModalData>>
+}>) => {
+  if (!state.isShow) return null
+  const dataList = []
+  for (const id in state.data) {
+    const value = state.data[id]
+    dataList.push([id, value])
+  }
+  const inputList = dataList.map(ary => {
+    const [id, value] = ary
+    return <SelectInputButton key={ id } id={ id } value={ value } state={ state } setState={ setState }/>
+  })
+  return (
+    <section
+      className="h-full w-full rounded-xl absolute z-index-10 p-4 bg-my-light-blue top-0 overflow-auto"
+    >
+      <h2 className="bg-my-yellow w-4/5 min-w-[360px] mx-auto rounded-full mb-4 select-none">作成するグッズの{ listName }を選んで下さい</h2>
+      { inputList }
+      <div>
+        { children }
+        <CloseModalButton state={ state } setState={ setState } charactersList={ charactersList } setChractersList={ setChractersList }/>
+      </div>
+    </section>
+  )
+}
+
+export default SelectModal

--- a/frontend/src/features/routes/create/components/closeModal.ts
+++ b/frontend/src/features/routes/create/components/closeModal.ts
@@ -1,0 +1,14 @@
+import ModalData from "../ModalData"
+
+const closeModal = (
+  state: ModalData,
+  setState: React.Dispatch<React.SetStateAction<ModalData>>,
+  cancelChoice: boolean = false,// 未選択状態に戻すフラグ
+) => {
+  const closedData: ModalData = !cancelChoice ?
+    {data: state.data, isShow: false, choiced: state.choiced} :
+    {data: state.data, isShow: false, choiced: ""}
+  setState(closedData)
+}
+
+export default closeModal

--- a/frontend/src/features/routes/create/getInputList.ts
+++ b/frontend/src/features/routes/create/getInputList.ts
@@ -1,0 +1,23 @@
+import { getRequestItemsCreate } from "@/utils/getRequest"
+import ModalData from "./ModalData"
+import processDataInputList from "./processDataInputList"
+
+const getInputList = async (
+  endpoint: string,
+  handleSetState: React.Dispatch<React.SetStateAction<ModalData>>,
+  seriesList?: ModalData,
+) => {
+  // 作品未選択でボタンを押している場合終了
+  if (endpoint === "characters" && seriesList && !seriesList.choiced) {
+    alert("作品を先に選択してください！")
+    return
+  }
+
+  const response = await getRequestItemsCreate(endpoint, seriesList?.choiced)
+  // console.log(response)
+
+  const result = processDataInputList(response)
+  handleSetState(result)
+}
+
+export default getInputList

--- a/frontend/src/features/routes/create/processDataInputList.ts
+++ b/frontend/src/features/routes/create/processDataInputList.ts
@@ -1,0 +1,9 @@
+import ModalData from "./ModalData"
+
+const processDataInputList = (
+  response: object,
+): ModalData => {
+  return {data: response, isShow: true, choiced: ""}
+}
+
+export default processDataInputList

--- a/frontend/src/features/routes/create/setInputList.ts
+++ b/frontend/src/features/routes/create/setInputList.ts
@@ -1,0 +1,12 @@
+import ModalData from "./ModalData"
+
+const setInputList = (
+  id: string,
+  state: ModalData,
+  setState: React.Dispatch<React.SetStateAction<ModalData>>,
+) => {
+  const newState: ModalData = {data: state.data, isShow: false, choiced: id}
+  setState(newState)
+}
+
+export default setInputList

--- a/frontend/src/features/routes/items/getItemsByQuery.ts
+++ b/frontend/src/features/routes/items/getItemsByQuery.ts
@@ -1,6 +1,6 @@
 import PageState from "@/features/common/pagenation/PageState"
-import { getRequest } from "@/utils/getRequest"
 // import testResponse from "@/utils/testResponse"
+import { getRequestItems } from "@/utils/getRequest"
 import ItemSearchResponse from "./ItemSearchResponse"
 import processData from "./processData"
 // stateのクエリパラメータ変更がトリガーでitemsのデータを取得するための関数
@@ -11,7 +11,7 @@ const getItemsByQuery = async (
   if (!searchInput.size) return processData()
 
   // 以下2行は、入れ替えで固定データとフェッチが切り替わる
-  const response = await getRequest("items", searchInput, pageState.currentPage)
+  const response = await getRequestItems("items", searchInput, pageState.currentPage)
   // const response = testResponse(searchInput, pageState.currentPage)
 
   const result = processData(response)

--- a/frontend/src/utils/getRequest.ts
+++ b/frontend/src/utils/getRequest.ts
@@ -1,14 +1,11 @@
-/**
- * 
- * @param endpoint /から続く、先頭と最後の/は不要
- * @param searchInput
- */
-export const getRequest = async (
+// items
+const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL
+
+export const getRequestItems = async (
   endpoint: string,
   searchInput: URLSearchParams,
   currentPage: number,
 ) => {
-  const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL
   const baseURL = `${ apiBaseUrl }${ endpoint }`
   const newSearchInput = new URLSearchParams(searchInput)
   newSearchInput.append("currentPage", currentPage.toString())
@@ -23,5 +20,17 @@ export const getRequest = async (
   //   console.error("接続エラー:", e)
   // })
   // 要ネットワークエラー処理と、fetchの返り値の考慮
+  return response === undefined ? Response.json({}) : response.json()
+}
+      
+export const getRequestItemsCreate = async (
+  endpoint: string,
+  choiced?: string,
+) => {
+  const onlyCharacterParameter = choiced ? `&seriesId=${ choiced }` : ""
+  const requestUrl = `${ apiBaseUrl }items/create?endpoint=${ endpoint }${ onlyCharacterParameter }`
+
+  const response = await fetch(requestUrl)
+
   return response === undefined ? Response.json({}) : response.json()
 }

--- a/frontend/src/utils/sendFormAction.ts
+++ b/frontend/src/utils/sendFormAction.ts
@@ -1,0 +1,36 @@
+"use server"
+
+const sendFormAction = async (
+  formData: FormData,
+  endpoint: string,
+  requires: string[],
+): Promise<{category_id?: string, category_name?: string, character_id: string, series_id: string} | void> => {
+  console.log("--------------------", requires)
+  console.log("--------------------", formData)
+  // 空白パラメータは除去 & 必須項目が空白の場合リクエスト中止
+  const newFormData = new FormData()
+  for (const query of formData.entries()) {
+    const key = query[0]
+    const value = query[1]
+    if (value !== "") {
+      newFormData.append(key, value)
+    }
+  }
+  for (const requireKey of requires) {
+    if (!newFormData.get(requireKey)) return
+  }
+
+  const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL
+  const requestUrl = `${ apiBaseUrl }${ endpoint }`
+  
+  const response = await fetch(
+    requestUrl,
+    {
+      method: "POST",
+      body: newFormData
+    })
+
+  return response.status === 200 ? response.json() : null
+}
+
+export default sendFormAction


### PR DESCRIPTION
グッズ作成機能とそれに関わる機能を実装しました

①各フォームの仕様
必須項目は作品名・キャラ名・商品名・グッズカテゴリーの4つです
未入力だと送信ボタンを押してもエラーが出ます
janコードは英数字以外が入っているとエラーに
年月日は日付入力フォームです
- 作品名・キャラ名・グッズカテゴリー
押すとモーダルが開いて、既存の一覧をすべて表示します
その選択肢を押すとモーダルは閉じてリストに選択された状態になります
キャラ名は作品名で絞るため、作品名をを選択済みでないと押してもアラートが出るだけです
作品名の作成をする場合はキャラも一緒に作成する必要があります
モーダルの下部に選択を解除して戻るボタンと新規作成フォームがあります
作品を解除するとキャラの選択も解除されます
②登録について
- 作品名・キャラ名・グッズカテゴリー
登録が完了するとモーダルが閉じて選択済みで戻るようになっています
登録が失敗した場合は、エラーモーダルが開いた状態になります
- アイテム登録
登録が完了するとTOPに戻ります
登録が失敗するとエラーモーダルが開きます
その場合上記3つ以外の入力内容は消えます
③試したこと
全ての実装項目について手動で動作の確認をしています
確認できた範囲のエラーは修正していますが、網羅はできていないと思います
また、速度重視の為にコミットやコードやコンポーネントの整理をかなり省略しております
機能的に問題があるかを今回は見て頂きたいです

アイテム作成の必須項目は作品名・キャラ名・グッズ名・カテゴリーの4つです


未解決項目
1.画像登録
2.モーダルの細かい位置やデザイン調整
3.フォームのバリデーション
4.フェッチその他でのエラー対応
5.TypeScriptの型エラーが数件残ってます(問題は起きないとは思っているのですが)