### PR TITLE
[fix] 独自データを持たないユーザーのエラー修正

### DIFF
--- a/backend/app/api/item.py
+++ b/backend/app/api/item.py
@@ -306,10 +306,10 @@ async def get_filtered_items(
 
             all_item_ids = set(original_series_item_ids + custom_series_item_ids)
 
-            if all_item_ids:
-                query_conditions.append({"_id": {"$in": list(all_item_ids)}})
+            if not all_item_ids:
+                return {"message": "No items found matching the queries."}
 
-
+            query_conditions.append({"_id": {"$in": list(all_item_ids)}})
 
 
         if character_name:
@@ -352,8 +352,10 @@ async def get_filtered_items(
             # 結果を統合
             all_item_ids = set(original_character_item_ids + custom_character_item_ids)
 
-            if all_item_ids:
-                query_conditions.append({"_id": {"$in": list(all_item_ids)}})
+            if not all_item_ids:
+                return {"message": "No items found matching the queries."}
+
+            query_conditions.append({"_id": {"$in": list(all_item_ids)}})
                 
 
         if item_name:
@@ -379,8 +381,11 @@ async def get_filtered_items(
                 
             # 両方の結果を条件に追加
             all_item_ids = set(original_item_ids + custom_item_ids)
-            if all_item_ids:
-                query_conditions.append({"_id": {"$in": list(all_item_ids)}})
+
+            if not all_item_ids:
+                return {"message": "No items found matching the queries."}
+
+            query_conditions.append({"_id": {"$in": list(all_item_ids)}})                
 
         if category_id:
             category_id = ObjectId(category_id)
@@ -412,8 +417,11 @@ async def get_filtered_items(
             ]                      
                
             all_item_ids = set(original_category_item_ids + custom_category_item_ids)
-            if all_item_ids:
-                query_conditions.append({"_id": {"$in": list(all_item_ids)}})
+
+            if not all_item_ids:
+                return {"message": "No items found matching the queries."}
+
+            query_conditions.append({"_id": {"$in": list(all_item_ids)}})
                 
         if tags_list:
             original_tag_conditions = []
@@ -454,9 +462,10 @@ async def get_filtered_items(
                     ]
                     custom_item_ids.extend(matching_custom_items)
 
-            all_item_ids = set(original_item_ids + custom_item_ids)
-            if all_item_ids:
-                query_conditions.append({"_id": {"$in": list(all_item_ids)}})
+            if not all_item_ids:
+                return {"message": "No items found matching the queries."}
+
+            query_conditions.append({"_id": {"$in": list(all_item_ids)}})
 
         if jan_code:
             query_conditions.append({"jan_code": jan_code})
@@ -499,8 +508,10 @@ async def get_filtered_items(
             # 結果を統合
             all_item_ids = set(original_item_ids_list + custom_item_ids)
 
-            if all_item_ids:
-                query_conditions.append({"_id": {"$in": list(all_item_ids)}})
+            if not all_item_ids:
+                return {"message": "No items found matching the queries."}
+
+            query_conditions.append({"_id": {"$in": list(all_item_ids)}})
 
         if not query_conditions:
             return {

--- a/backend/app/api/item.py
+++ b/backend/app/api/item.py
@@ -738,11 +738,11 @@ async def update_custom_item(
             )            
 
             custom_item = await create_custom_item(user_specific_data, custom_item)
-            if not custom_item:
-                raise HTTPException(status_code=500, detail="Failed to create custom item")            
-           
             await user_specific_data.save()
-
+            if not custom_item:
+                raise HTTPException(status_code=500, detail="Failed to create custom item") 
+           
+        await user_specific_data.save()
         return custom_item
 
     except ValidationError as e:
@@ -801,6 +801,7 @@ async def change_exchange_status(item_id: str, status: bool, user_id: str = Depe
                 own_status = None       
             )
             custom_item = await create_custom_item(user_specific_data, custom_item)
+
 
         # 欲しい/譲れるフラグ変更
         if status is not None:


### PR DESCRIPTION
独自データを持たないユーザが検索作業をしようとすると
エラーになる不具合を修正しました

他以下エラーも修正
独自データを持たない時の最初の編集時のエラー修正
カスタムアイテムを持っているのに検索で独自シリーズが含まれていないエラー修正
カスタムアイテムを持っているのに検索で独自キャラクターが含まれない不具合修正
カスタムアイテムを持っているのに上書きされない不具合修正
