### PR TITLE
[add,fix] signup,login,logout機能を実装 セッション機能実装 リクエスト周りのcookie調整

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,2 +1,3 @@
 NEXT_PUBLIC_API_BASE_URL=http://localhost:3000/api/
 BACKEND_API_URL=http://fastapi:8000/api/
+BACKEND_AUTH_URL=http://fastapi:8000/

--- a/frontend/src/app/api/categories/route.ts
+++ b/frontend/src/app/api/categories/route.ts
@@ -1,3 +1,4 @@
+import makeToken from "@/utils/makeToken"
 import { NextRequest } from "next/server"
 
 const backendUrl = process.env.BACKEND_API_URL
@@ -5,6 +6,10 @@ const backendUrl = process.env.BACKEND_API_URL
 export async function POST(
   request: NextRequest,
 ) {
+  const cookie = request.headers.get("set-cookie")
+  if (!cookie) return Response.error()
+  const token = makeToken(cookie)
+
   const formData = await request.formData()
   const searchParams = new URLSearchParams(formData)
   const requestUrl = `${ backendUrl }categories?${ searchParams }`
@@ -12,6 +17,9 @@ export async function POST(
     requestUrl,
     {
       method: "POST",
+      headers: {
+        Authorization: token,
+      }
     }
   )
 

--- a/frontend/src/app/api/getImageUrl/route.ts
+++ b/frontend/src/app/api/getImageUrl/route.ts
@@ -1,0 +1,30 @@
+import { TOKEN_PREFIX as pre } from "@/constants"
+import { NextRequest } from "next/server"
+
+const backendUrl = process.env.BACKEND_API_URL
+
+export async function GET(
+  request: NextRequest,
+) {
+  const cookie = request.cookies.get("fantre")
+
+  if (!cookie) return Response.error()
+  const token = `${ pre }${ cookie.value }`
+
+  const searchParams = request.nextUrl.searchParams
+  const endpoint = searchParams.get("endpoint")
+
+  if (!endpoint) return Response.error()
+
+  const requestUrl = `${ backendUrl }${ endpoint }`
+  const response = await fetch(
+    requestUrl,
+    {
+      headers: {
+        Authorization: token,
+      }
+    }
+  )
+
+  return response
+}

--- a/frontend/src/app/api/items/route.ts
+++ b/frontend/src/app/api/items/route.ts
@@ -1,9 +1,14 @@
+import makeToken from "@/utils/makeToken"
 import { NextRequest } from "next/server"
 
 export async function GET(
   request: NextRequest,
 ) {
   // これはapi/items/にリクエストとしてきたものを受け取る
+  const cookie = request.headers.get("cookie")
+  if (!cookie) return Response.error()
+  const token = makeToken(cookie)
+
   const searchParams = request.nextUrl.searchParams
   const pageParam = searchParams.get("currentPage") || 1
   searchParams.delete("currentPage")
@@ -11,7 +16,14 @@ export async function GET(
   const backendUrl = process.env.BACKEND_API_URL
   const requestUrl = `${ backendUrl }items/page/${ pageParam }?${ searchParams }`
 
-  const response = await fetch(requestUrl)
+  const response = await fetch(
+    requestUrl,
+    {
+      headers: {
+        Authorization: token,
+      }
+    }
+  )
   // エラー処理が必要(空検索は対応済み サーバーエラーなど 未定)
   return response
 }

--- a/frontend/src/app/api/login/route.ts
+++ b/frontend/src/app/api/login/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest } from "next/server"
+
+const backendUrl = process.env.BACKEND_AUTH_URL
+
+export async function POST(
+  request: NextRequest,
+) {
+  const formData = await request.formData()
+  const requestUrl = `${ backendUrl }login`
+  // emailのkeyをusernameとして送る処理
+  const requires = ["username", "password"]
+  const searchParams = new URLSearchParams()
+  for (const form of formData.entries()) {
+    const key = form[0] === "email" ? requires[0] : form[0]
+    const value = form[1].toString()
+    if (requires.includes(key)) searchParams.append(key, value)
+  }
+  if (searchParams.size < requires.length) return
+
+  const response = await fetch(
+    requestUrl,
+    {
+      headers: {"Content-Type":"application/x-www-form-urlencoded"},
+      method: "POST",
+      body: searchParams.toString(),
+    }
+  )
+
+  return response
+}

--- a/frontend/src/app/api/route.ts
+++ b/frontend/src/app/api/route.ts
@@ -1,0 +1,35 @@
+import {
+  IMAGE_FORMAT_ALLOW_LIST as allowedImages,
+  MIME_TO_EXTENSION as extensions,
+} from "@/constants"
+import makeToken from "@/utils/makeToken"
+import { NextRequest } from "next/server"
+
+const backendUrl = process.env.BACKEND_API_URL
+
+export async function POST(
+  request: NextRequest,
+) {
+  const cookie = request.headers.get("set-cookie")
+  if (!cookie) return Response.error()
+  const token = makeToken(cookie)
+  const imageFile = await request.blob()
+
+  if (!imageFile.size || !allowedImages.includes(imageFile.type)) return Response.error()
+  const requestUrl = `${ backendUrl }user/bg-images`
+  const formData = new FormData()
+  // 第三引数に拡張子付きのfile名が必須
+  formData.append("bg_image", imageFile, `Next${ extensions[imageFile.type] }`)
+  const response = await fetch(
+    requestUrl,
+    {
+      method: "POST",
+      headers: {
+        Authorization: token,
+      },
+      body: formData,
+    }
+  )
+
+  return response
+}

--- a/frontend/src/app/api/series-characters/route.ts
+++ b/frontend/src/app/api/series-characters/route.ts
@@ -1,3 +1,4 @@
+import makeToken from "@/utils/makeToken"
 import { NextRequest } from "next/server"
 
 const backendUrl = process.env.BACKEND_API_URL
@@ -5,6 +6,10 @@ const backendUrl = process.env.BACKEND_API_URL
 export async function POST(
   request: NextRequest,
 ) {
+  const cookie = request.headers.get("set-cookie")
+  if (!cookie) return Response.error()
+  const token = makeToken(cookie)
+
   const formData = await request.formData()
   // booleanに変換
   const isNewSeries = formData.get("is_new_series") === "true"
@@ -18,7 +23,10 @@ export async function POST(
   const response = await fetch(
     requestUrl,
     {
-      headers: {"Content-Type":"application/json"},
+      headers: {
+        "Content-Type":"application/json",
+        Authorization: token,
+      },
       method: "POST",
       body: json
     }

--- a/frontend/src/app/api/signup/route.ts
+++ b/frontend/src/app/api/signup/route.ts
@@ -1,0 +1,30 @@
+import { BACKEND_AUTH_KEYS as keys } from "@/constants"
+import { NextRequest } from "next/server"
+
+const backendUrl = process.env.BACKEND_AUTH_URL
+
+export async function POST(
+  request: NextRequest,
+) {
+  const formData = await request.formData()
+  const requestUrl = `${ backendUrl }signup`
+  const requires = [keys.email, keys.name, keys.pass1, keys.pass2]
+  const searchParams = new URLSearchParams()
+  for (const form of formData.entries()) {
+    const key = form[0]
+    const value = form[1].toString()
+    if (requires.includes(key)) searchParams.append(key, value)
+  }
+  if (searchParams.size < requires.length) return
+
+  const response = await fetch(
+    requestUrl,
+    {
+      headers: {"Content-Type":"application/x-www-form-urlencoded"},
+      method: "POST",
+      body: searchParams.toString(),
+    }
+  )
+
+  return response
+}

--- a/frontend/src/app/items/[itemId]/page.tsx
+++ b/frontend/src/app/items/[itemId]/page.tsx
@@ -1,7 +1,7 @@
 import InputButton from "@/components/InputButton"
 import MonitorLayout from "@/components/MonitorLayout"
 import TopButton from "@/components/TopButton"
-import ImageUploadForm from "@/features/common/ImageUploadForm"
+import ImageUploadForm from "@/features/common/uploadImage/ImageUploadForm"
 
 const ItemDetailPage = () => {
   return (

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -2,17 +2,50 @@ import InputButton from "@/components/InputButton"
 import LinkButton from "@/components/LinkButton"
 import MonitorLayout from "@/components/MonitorLayout"
 import SubmitButton from "@/components/SubmitButton"
+import {
+  COOKIE_OPTIONS as cookieOptions,
+  // VALIDATION_EMAIL as emailPattern,
+  VALIDATION_PASSWORD as passwordPattern,
+} from "@/constants"
+import authAction from "@/utils/authAction"
+import { cookies } from "next/headers"
+import { redirect } from "next/navigation"
 
 const LoginPage = () => {
+  const requires = ["email", "password"]
   return (
     <MonitorLayout
       headerContent={ <LinkButton href="/"addClass="mr-0">TOPへ(仮置き)</LinkButton> }
       viewContent={
         <form
           className="h-full flex flex-col justify-around"
+          action={
+            async formData => {
+              "use server"
+              const result = await authAction(formData, "login", requires)
+              if (result) {// cookieにtokenを保存する
+                const token = result.access_token || ""
+                const cookieStore = await cookies()
+                cookieStore.set("fantre", token, cookieOptions)
+                redirect("/")
+              }
+            }
+          }
         >
-          <InputButton placeholder="メールアドレス"/>
-          <InputButton placeholder="パスワード"/>
+          <InputButton
+            type="email"
+            inputName={ requires[0] }
+            placeholder="メールアドレス"
+            // pattern={ emailPattern }うまく機能しないのでコメントアウト
+            required
+          />
+          <InputButton
+            type="password"
+            inputName={ requires[1] }
+            placeholder="パスワード"
+            pattern={ passwordPattern }
+            required
+          />
           <SubmitButton>ログイン</SubmitButton>
         </form>
       }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,14 +1,51 @@
+"use client"
+
 import BackgroundImageViewer from "@/components/BackgroundImageViewer"
 import LinkButton from "@/components/LinkButton"
 import MonitorLayout from "@/components/MonitorLayout"
 import TopNaviContent from "@/components/TopNaviContent"
+import fetchImage from "@/features/common/getImage/fetchImage"
+import getImageUrl from "@/features/common/getImage/getImageUrl"
 import LogoutButton from "@/features/routes/top/components/LogoutButton"
+import { useEffect, useState } from "react"
 
 const Home = () => {
+  // イメージの取得先のURL
+  const [imageUrl, setImageUrl] = useState<string>("")
+  // backgroundImageのsrcとしての画像のアクセスURL
+  const [imageSrcUrl, setImageSrcUrl] = useState<string>("")
+
+  useEffect(()=> {// effectではない方法で管理できる方がパフォーマンスいいかも
+    // イメージの取得先のURLを取得する
+    const endpoint = "user/bg-images"
+
+    const fetchData = async () => {
+      const response = await getImageUrl(endpoint)
+      if (response && imageUrl !== response) setImageUrl(response)
+    }
+    fetchData()
+  })
+
+  useEffect(() => {
+    // 取得先が有効ならがぞうを取得してブラウザ内のURLとして保存する
+    const fetchData = async () => {
+      if (imageUrl === "") return
+      const response = await fetchImage(imageUrl)
+      const blob = await response.blob()
+      const srcUrlImageFile = URL.createObjectURL(blob)
+      if (srcUrlImageFile && srcUrlImageFile !== imageSrcUrl) setImageSrcUrl(srcUrlImageFile)
+    }
+    fetchData()
+  }, [imageUrl])
+
   return (
     <MonitorLayout
       headerContent={ <LogoutButton/> }
-      viewContent={ <BackgroundImageViewer/> }
+      viewContent={
+        <BackgroundImageViewer
+          imageUrl={ imageSrcUrl }
+        />
+      }
       naviContent={ <TopNaviContent/> }
       footerContent={ <LinkButton addClass="mr-0" href="/login">ログインへ(仮置き)</LinkButton> }
     />

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -2,19 +2,54 @@ import InputButton from "@/components/InputButton"
 import LinkButton from "@/components/LinkButton"
 import MonitorLayout from "@/components/MonitorLayout"
 import SubmitButton from "@/components/SubmitButton"
+import {
+  BACKEND_AUTH_KEYS as keys,
+  // VALIDATION_EMAIL as emailPattern,
+  VALIDATION_PASSWORD as passwordPattern,
+} from "@/constants"
+import authAction from "@/utils/authAction"
+import { redirect } from "next/navigation"
 
 const SignupPage = () => {
+  const requires = [keys.email, keys.name, keys.pass1, keys.pass2]
   return (
     <MonitorLayout
       headerContent
       viewContent={
         <form
           className="h-full flex flex-col justify-around"
+          action={
+            async formData => {
+              "use server"
+              const result = await authAction(formData, "signup", requires)
+              if (result) {
+                redirect("/login")
+              }
+            }
+          }
         >
-          <InputButton placeholder="メールアドレス"/>
-          <InputButton placeholder="ニックネーム"/>
-          <InputButton placeholder="パスワード"/>
-          <InputButton placeholder="パスワード確認用"/>
+          <InputButton
+            type="email"
+            inputName={ keys.email }
+            placeholder="メールアドレス"
+            // pattern={ emailPattern }
+            required
+          />
+          <InputButton inputName={ keys.name } placeholder="ニックネーム" required/>
+          <InputButton
+            type="password"
+            inputName={ keys.pass1 }
+            placeholder="パスワード"
+            pattern={ passwordPattern }
+            required
+          />
+          <InputButton
+            type="password"
+            inputName={ keys.pass2 }
+            placeholder="パスワード確認用"
+            pattern={ passwordPattern }
+            required
+          />
           <SubmitButton>登録する！</SubmitButton>
         </form>
       }

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -43,6 +43,12 @@ const SignupPage = () => {
             pattern={ passwordPattern }
             required
           />
+          <div className="bg-my-light-blue w-4/5 mx-auto rounded-full">
+            <p className="wrap">
+              パスワードは最低8文字で、<br/>
+              小英文字・大英文字・数字を各ひとつずつ含む必要があります
+            </p>
+          </div>
           <InputButton
             type="password"
             inputName={ keys.pass2 }

--- a/frontend/src/components/BackgroundImageViewer.tsx
+++ b/frontend/src/components/BackgroundImageViewer.tsx
@@ -1,14 +1,18 @@
 import Image from "next/image"
 
-const BackgroundImageViewer = () => {
-  return (
+const BackgroundImageViewer = ({
+  imageUrl = "",
+}: Readonly<{
+  imageUrl: string
+}>) => {
+  const image = imageUrl === "" ? null :
     <Image
       fill
-      src="/torio.png"
+      src={ imageUrl }
       alt="背景として表示する画像です"
       style={{objectFit:"contain"}}
     />
-  )
+  return image
 }
 
 export default BackgroundImageViewer

--- a/frontend/src/components/TopNaviContent.tsx
+++ b/frontend/src/components/TopNaviContent.tsx
@@ -1,4 +1,4 @@
-import ImageUploadForm from "@/features/common/ImageUploadForm"
+import ImageUploadForm from "@/features/common/uploadImage/ImageUploadForm"
 import BackgroundImageResetButton from "@/features/components/BackgroundImageResetButton"
 import LinkButton from "./LinkButton"
 import LinkSet from "./LinkSet"
@@ -19,6 +19,8 @@ const TopNaviContent = () => {
           formId="top-page-form"
           buttonText="画像送信"
           uploadImageText="背景画像を設定する"
+          endpoint=""
+          imageId="bg_image"
         />
         <BackgroundImageResetButton/>
       </div>

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -9,3 +9,23 @@ export const BACKEND_ITEM_KEYS = {
   retailers: "retailers",
   image: "item_images",
 }
+
+export const BACKEND_AUTH_KEYS = {
+  name: "user_name",
+  email: "email",
+  pass1: "password1",
+  pass2: "password2",
+}
+
+// https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/Set-Cookie
+export const COOKIE_OPTIONS = {
+  maxAge: 10000,
+  // secure: true,
+  httpOnly: true,
+}
+
+export const TOKEN_PREFIX = "Bearer "
+
+export const VALIDATION_EMAIL = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
+// 8字以上 & 数値1以上 & 小英数1以上 & 大英数1以上
+export const VALIDATION_PASSWORD = "(?=.*\\d)(?=.*[a-z])(?=.*[A-Z]).{8,}"

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -26,6 +26,18 @@ export const COOKIE_OPTIONS = {
 
 export const TOKEN_PREFIX = "Bearer "
 
+export const IMAGE_FORMAT_ALLOW_LIST = [
+  "image/png",
+  "image/jpg",
+  "image/jpeg",
+]
+
+export const MIME_TO_EXTENSION = {
+  "image/png": ".png",
+  "image/jpg": ".jpg",
+  "image/jpeg": ".jpeg",
+}
+
 export const VALIDATION_EMAIL = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
 // 8字以上 & 数値1以上 & 小英数1以上 & 大英数1以上
 export const VALIDATION_PASSWORD = "(?=.*\\d)(?=.*[a-z])(?=.*[A-Z]).{8,}"

--- a/frontend/src/features/common/getImage/fetchImage.ts
+++ b/frontend/src/features/common/getImage/fetchImage.ts
@@ -1,0 +1,13 @@
+const fetchImage = async (
+  imageUrl: string,
+) => {
+  const response = await fetch(
+    imageUrl,
+    {
+      cache: "force-cache",
+    }
+  )
+  return response
+}
+
+export default fetchImage

--- a/frontend/src/features/common/getImage/getImageUrl.ts
+++ b/frontend/src/features/common/getImage/getImageUrl.ts
@@ -1,0 +1,10 @@
+const getImageUrl = async (
+  endpoint: string,
+) => {
+  const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || ""
+  const response = await fetch(`${ apiBaseUrl }/getImageUrl?endpoint=${ endpoint }`)
+
+  return response?.status === 200 ? await response.json() : null
+}
+
+export default getImageUrl

--- a/frontend/src/features/common/uploadImage/ImageUploadForm.tsx
+++ b/frontend/src/features/common/uploadImage/ImageUploadForm.tsx
@@ -1,17 +1,23 @@
+import { IMAGE_FORMAT_ALLOW_LIST as allowedImages } from "@/constants"
 import concatClassName from "@/utils/concatClassName"
+import uploadImage from "./uploadImageForm"
 
 const ImageUploadForm = ({
   formId,
   children,
   uploadImageText,
   buttonText,
-  addClass = ""
+  addClass = "",
+  endpoint,
+  imageId,
 }: Readonly<{
   formId: string
   children?: React.ReactNode
   uploadImageText: string
   buttonText: string
   addClass?: string
+  endpoint: string
+  imageId: string
 }>) => {
   const formBaseClass = "mx-auto flex flex-col"
   const className = concatClassName(formBaseClass, addClass)
@@ -21,7 +27,7 @@ const ImageUploadForm = ({
       className={ className }
       id={ formId }
       name={ formId }
-      // action
+      action={ formData => uploadImage(formData, endpoint) }
     >
       { children }
       <div>
@@ -32,10 +38,11 @@ const ImageUploadForm = ({
           { uploadImageText }
         </label>
         <input
-          accept="image/*"
+          accept={ allowedImages.join(",") }
           type="file"
           id={ formId }
           className="file:opacity-0 file:block file:bg-my-orange file:h-0 file:border-0 h-[40px] mx-auto rounded-[40px] pl-10 bg-my-orange leading-normal cursor-pointer w-60"
+          name={ imageId }
         />
       </div>
       <button

--- a/frontend/src/features/common/uploadImage/uploadImageForm.ts
+++ b/frontend/src/features/common/uploadImage/uploadImageForm.ts
@@ -1,0 +1,39 @@
+"use server"
+
+import { cookies } from "next/headers"
+import { redirect } from "next/navigation"
+
+const uploadImageForm = async (
+  formData: FormData,
+  endpoint: string,
+) => {
+  const cookie = (await cookies()).get("fantre")
+  if (!cookie) return
+  const imageFile = formData.get("bg_image")
+  if (!imageFile) return
+
+  const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL
+  const requestUrl = `${ apiBaseUrl }${ endpoint }`
+
+  const cookieKey = cookie.name
+  const cookieValue = cookie.value
+
+  const header = new Headers({"Set-Cookie": `${ cookieKey }=${ cookieValue }`})
+  await fetch(
+    requestUrl,
+    {
+      method: "POST",
+      headers: header,
+      body: imageFile,
+    }
+  ).then(res => {
+    if (res.status === 200) {
+      redirect("/")
+    } else {
+      // redirect("/error")
+    }
+  })
+
+}
+
+export default uploadImageForm

--- a/frontend/src/features/routes/top/components/LogoutButton.tsx
+++ b/frontend/src/features/routes/top/components/LogoutButton.tsx
@@ -1,13 +1,17 @@
-import OnClickButton from "@/features/common/OnClickButton"
-
+import logoutAction from "../logoutAction"
 
 const LogoutButton = () => {
   return (
-    <OnClickButton
-      addClass="mr-0 bg-my-yellow w-[136px] max-h-[32px] leading-none"
+    <form
+      className="block ml-auto py-2 rounded-3xl text-center bg-my-yellow w-[136px] max-h-[32px] leading-none"
+      action={ logoutAction }
     >
-      ログアウト
-    </OnClickButton>
+      <button>
+        <p>
+          ログアウト
+        </p>
+      </button>
+    </form>
   )
 }
 

--- a/frontend/src/features/routes/top/logoutAction.ts
+++ b/frontend/src/features/routes/top/logoutAction.ts
@@ -1,0 +1,13 @@
+"use server"
+
+import { cookies } from "next/headers"
+import { redirect } from "next/navigation"
+
+const logoutAction = async () => {
+  const cookieStore = await cookies()
+  cookieStore.delete("fantre")
+
+  redirect("/login")
+}
+
+export default logoutAction

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,22 @@
+import { cookies } from "next/headers"
+import type { NextRequest } from "next/server"
+import { NextResponse } from "next/server"
+
+export const middleware = async (
+  request: NextRequest,
+) => {
+  const cookieStore = await cookies()
+  const cookie = cookieStore.get("fantre")
+  if (!cookie) return NextResponse.redirect(new URL("login", request.url))
+}
+
+export const config = {
+  matcher: [
+    "/:path",
+    "/items/:path*",
+    "/series/:path*",
+    "/lists/:path*",
+    "/chat/:path*",
+    "/calender/:path*",
+  ]
+}

--- a/frontend/src/utils/authAction.ts
+++ b/frontend/src/utils/authAction.ts
@@ -1,14 +1,10 @@
 "use server"
 
-import { cookies } from "next/headers"
-
-const sendFormAction = async (
+const authAction = async (
   formData: FormData,
   endpoint: string,
   requires: string[],
-): Promise<{category_id?: string, category_name?: string, character_id: string, series_id: string, access_token?: string} | void> => {
-  console.log("--------------------", requires)
-  console.log("--------------------", formData)
+): Promise<{access_token: string} | void> => {
   // 空白パラメータは除去 & 必須項目が空白の場合リクエスト中止
   const newFormData = new FormData()
   for (const query of formData.entries()) {
@@ -22,14 +18,6 @@ const sendFormAction = async (
     if (!newFormData.get(requireKey)) return
   }
 
-  const cookieStore = cookies()
-  const cookie = (await cookieStore).get("fantre")
-  if (!cookie) return
-  const cookieKey = cookie.name
-  const cookieValue = cookie.value
-  if (cookieKey !== "fantre") return
-
-  const header = new Headers({"Set-Cookie": `${ cookieKey }=${ cookieValue }`})
   const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL
   const requestUrl = `${ apiBaseUrl }${ endpoint }`
   
@@ -37,11 +25,10 @@ const sendFormAction = async (
     requestUrl,
     {
       method: "POST",
-      headers: header,
       body: newFormData
     })
 
   return response.status === 200 ? response.json() : null
 }
 
-export default sendFormAction
+export default authAction

--- a/frontend/src/utils/getRequest.ts
+++ b/frontend/src/utils/getRequest.ts
@@ -20,7 +20,7 @@ export const getRequestItems = async (
   //   console.error("接続エラー:", e)
   // })
   // 要ネットワークエラー処理と、fetchの返り値の考慮
-  return response === undefined ? Response.json({}) : response.json()
+  return response.status !== 200 ? null : response.json()
 }
       
 export const getRequestItemsCreate = async (
@@ -32,5 +32,5 @@ export const getRequestItemsCreate = async (
 
   const response = await fetch(requestUrl)
 
-  return response === undefined ? Response.json({}) : response.json()
+  return response.status !== 200 ? null : response.json()
 }

--- a/frontend/src/utils/makeToken.ts
+++ b/frontend/src/utils/makeToken.ts
@@ -1,0 +1,9 @@
+import { TOKEN_PREFIX as pre } from "@/constants"
+
+const makeToken = (cookie: string): string => {
+  const cookieValue = cookie.split("=")[1]
+  // この形式のトークン文字列をfastapiへのリクエストヘッダのAuthorization:にセットする必要がある
+  return `${ pre }${ cookieValue }`
+}
+
+export default makeToken


### PR DESCRIPTION
signup,login,logout機能を実装しました
それに伴ってセッション管理機能を追加しました

①signup,login
全ての入力欄への入力を必須としています
入力値のバリデーションは簡単に実装しました
サインアップに成功するとログインに
ログインに成功するとTopにとびます
②セッション管理について
signupとlogin以外へのページ閲覧アクセスはcookieがないとloginにリダイレクトするようにしました(middlewareによって)
機能に付随する認証は各エンドポイントや関数でcookieにて直接行います
③logout
ログアウトを押すとcookieが削除されてloginにリダイレクトします

試したこと
各操作を行ってとりあえず想定通りに動くことを確認しました