### PR TITLE
コレクションリストへグッズの複数追加・削除対応

### DIFF
--- a/backend/app/database/db_collection_list.py
+++ b/backend/app/database/db_collection_list.py
@@ -41,14 +41,18 @@ async def get_collection_list(user_id: ObjectId):
 
 
 # コレクションリストにグッズ追加
-async def add_item_to_list(list_id: ObjectId, item_id: ObjectId, user_id: ObjectId):
+async def add_item_to_list(list_id: ObjectId, item_id: List[ObjectId], user_id: ObjectId):
     try:
         await db.connect()
         user = await User.find_one({"_id": user_id})
         user_collection_lists = user.collection_lists
         for list in user_collection_lists:
             if list.id == list_id:
-                list.list_items.append(item_id)
+                for item in item_id:
+                    if item in list.list_items:
+                        continue
+                    else:
+                        list.list_items.append(item)
         await user.save()
     except ValidationError as ve:
         raise HTTPException(status_code=422, detail=ve.errors())
@@ -59,14 +63,18 @@ async def add_item_to_list(list_id: ObjectId, item_id: ObjectId, user_id: Object
 
 
 # コレクションリストからグッズ削除
-async def delete_item_from_list(list_id: ObjectId, item_id: ObjectId, user_id: ObjectId):
+async def delete_item_from_list(list_id: ObjectId, item_id: List[ObjectId], user_id: ObjectId):
     try:
         await db.connect()
         user = await User.find_one({"_id": user_id})
         user_collection_lists = user.collection_lists
         for list in user_collection_lists:
             if list.id == list_id:
-                list.list_items.remove(item_id)
+                for item in item_id:
+                    if item not in list.list_items:
+                        continue
+                    else:
+                        list.list_items.remove(item)
         await user.save()
     except ValidationError as ve:
         raise HTTPException(status_code=422, detail=ve.errors())

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,22 +33,6 @@ app = FastAPI(lifespan=lifespan)
 #         content={"detail": "There was an error in your input. Please"}, status_code=status.HTTP_422_UNPROCESSABLE_ENTITY
 #     )
 
-# tokenデコードしてuser_id取得
-# def get_current_user(token: str = Depends(oauth2_scheme)):
-#     credentials_exception = HTTPException(
-#         status_code=401,
-#         detail="Could not validate credentials",
-#         headers={"WWW-Authenticate": "Bearer"},
-#     )
-#     try:
-#         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-#         user_id: str = payload.get("sub")
-        
-#         if user_id is None:
-#             raise credentials_exception
-#     except InvalidTokenError:
-#         raise credentials_exception
-#     return user_id
 
 # ルーター追加
 app.include_router(user_router)  # ユーザー関連のルーターを追加


### PR DESCRIPTION
タイトルの通りです。
既にリストに追加されているアイテムを入れようとした場合、エラーは返さずに無視します。
運用上無い気がしますが、リストにないけど登録はされているグッズを消そうとしたときも同様です。